### PR TITLE
Removing Ruby dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,7 +121,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-exec');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-sass');
 
   //
   // custom tasks

--- a/code/css/content.css
+++ b/code/css/content.css
@@ -1,39 +1,33 @@
 .aa-popup .aa-popup-content {
-  padding: 20px;
-}
+  padding: 20px; }
 .aa-popup h1 {
   text-align: center;
   font-size: 1em;
   line-height: 4em;
   border-bottom: solid 1px #EEEEEE;
-  margin: 0;
-}
+  margin: 0; }
 .aa-popup h2 {
   float: left;
   width: 100%;
   margin: 1.8em 0 0.5em;
   font-size: 1.2em;
   font-weight: 200;
-  color: #888888;
-}
+  color: #888888; }
 .aa-popup p {
   float: left;
   font-size: 1em;
   line-height: 1.5em;
   margin: 0.5em 0;
-  color: #333333;
-}
+  color: #333333; }
 .aa-popup ul {
   float: right;
   list-style: none;
   margin: 0;
-  padding: 10px 0 0;
-}
-.aa-popup ul li {
-  display: inline-block;
-  margin-left: 10px;
-  line-height: 2em;
-}
+  padding: 10px 0 0; }
+  .aa-popup ul li {
+    display: inline-block;
+    margin-left: 10px;
+    line-height: 2em; }
 .aa-popup button {
   width: 100%;
   font-size: 1.2em;
@@ -42,47 +36,36 @@
   border: solid 1px #2460ba;
   color: white;
   padding: 5px 10px;
-  cursor: pointer;
-}
-.aa-popup button img {
-  vertical-align: bottom;
-}
+  cursor: pointer; }
+  .aa-popup button img {
+    vertical-align: bottom; }
 .aa-popup .aa-algolia-logo {
   clear: both;
   width: 100px;
   display: block;
-  margin: 0 auto;
-}
-.aa-popup .aa-algolia-logo img {
-  width: 100%;
-}
+  margin: 0 auto; }
+  .aa-popup .aa-algolia-logo img {
+    width: 100%; }
 .aa-popup a {
   color: #3879D9;
-  text-decoration: none;
-}
-.aa-popup a:hover {
-  text-decoration: underline;
-}
+  text-decoration: none; }
+  .aa-popup a:hover {
+    text-decoration: underline; }
 .aa-popup a:focus, .aa-popup button:focus {
   outline: 0 !important;
-  box-shadow: none !important;
-}
+  box-shadow: none !important; }
 
 .awesome-autocomplete .twitter-typeahead {
-  width: 360px;
-}
+  width: 360px; }
 .awesome-autocomplete .tt-input {
   width: 100%;
   padding: 4px 6px;
   border: 1px solid #D8D8D8;
-  outline: none;
-}
+  outline: none; }
 .awesome-autocomplete .tt-hint {
-  color: #999;
-}
+  color: #999; }
 .awesome-autocomplete .tt-cursor {
-  background-color: #FFF9EA;
-}
+  background-color: #FFF9EA; }
 .awesome-autocomplete .tt-dropdown-menu {
   width: 800px;
   padding: 0;
@@ -90,196 +73,155 @@
   border-top: none;
   background-color: white;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
-  box-sizing: content-box;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-dataset-private, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-repos, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-issues, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-users {
-  margin: 0 5px;
-  width: 390px;
-  float: left;
-}
-.awesome-autocomplete .tt-dropdown-menu.single-dataset {
-  width: 400px;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-dataset-default, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-branding, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-current-repo {
-  clear: both;
-}
-.awesome-autocomplete .tt-dropdown-menu .aa-query {
-  padding: 8px;
-  color: #888888;
-  display: block;
-  width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.awesome-autocomplete .tt-dropdown-menu .aa-query .aa-query-cursor strong, .awesome-autocomplete .tt-dropdown-menu .aa-query .aa-query-default em {
-  color: #333333;
-}
-.awesome-autocomplete .tt-dropdown-menu .aa-branding {
-  padding: 10px;
-  text-align: right;
-  font-size: 0.9em;
-  color: #888888;
-}
-.awesome-autocomplete .tt-dropdown-menu .aa-branding img {
-  height: 18px;
-  vertical-align: bottom;
-}
-.awesome-autocomplete .tt-dropdown-menu .aa-category {
-  padding: 5px 8px;
-  font-weight: bold;
-  text-align: left;
-  background-color: #F5F5F5;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion {
-  padding: 10px 10px;
-  text-align: left;
-  border-bottom: 1px solid #EEEEEE;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion:last-child {
-  border-bottom: 0;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion em {
-  font-style: normal;
-  background-color: #FFFFC6;
-  color: #333333;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion:hover {
-  text-decoration: none;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion:hover .aa-name {
-  text-decoration: underline;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion .aa-infos {
-  float: right;
-  line-height: 3em;
-  color: #888888;
-  font-size: 0.9em;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion .aa-infos i {
-  font-size: 14px;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion .aa-name {
-  font-size: 1.1em;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user {
-  height: 35px;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-thumbnail {
-  float: left;
-  position: relative;
-  top: 3px;
-  width: 30px;
-  height: 30px;
-  margin-right: 10px;
-  border-radius: 3px;
-  overflow: hidden;
-  background-color: #F5F5F5;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-thumbnail img {
-  width: 100%;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-name {
-  font-weight: bold;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-login {
-  color: #888888;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-company {
-  color: #333333;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-company i {
-  font-size: 14px;
-  color: #888888;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo {
-  height: 3em;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-thumbnail {
-  float: left;
-  position: relative;
-  top: 3px;
-  width: 30px;
-  height: 30px;
-  margin-right: 10px;
-  border-radius: 3px;
-  overflow: hidden;
-  background-color: #F5F5F5;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-thumbnail img {
-  width: 100%;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-name {
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: normal;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-repo-name {
-  font-weight: bold;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-description {
-  height: 1.3em;
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: #888888;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-thumbnail {
-  float: left;
-  position: relative;
-  top: 3px;
-  width: 30px;
-  height: 30px;
-  margin-right: 10px;
-  border-radius: 3px;
-  overflow: hidden;
-  background-color: #F5F5F5;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-thumbnail img {
-  width: 100%;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-name {
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: normal;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-repo-name {
-  font-weight: bold;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-issue-number {
-  font-weight: bold;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-issue-body {
-  clear: both;
-  color: #888888;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-your-repo {
-  height: 1.5em;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-your-repo .aa-name {
-  width: 85%;
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: normal;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-your-repo .aa-name .aa-repo {
-  font-weight: bold;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-your-repo i {
-  font-size: 14px;
-}
-.awesome-autocomplete .tt-dropdown-menu .tt-dataset-current-repo .tt-suggestion {
-  padding: 0;
-}
+  box-sizing: content-box; }
+  .awesome-autocomplete .tt-dropdown-menu .tt-dataset-private, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-repos, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-issues, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-users {
+    margin: 0 5px;
+    width: 390px;
+    float: left; }
+  .awesome-autocomplete .tt-dropdown-menu.single-dataset {
+    width: 400px; }
+  .awesome-autocomplete .tt-dropdown-menu .tt-dataset-default, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-branding, .awesome-autocomplete .tt-dropdown-menu .tt-dataset-current-repo {
+    clear: both; }
+  .awesome-autocomplete .tt-dropdown-menu .aa-query {
+    padding: 8px;
+    color: #888888;
+    display: block;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis; }
+    .awesome-autocomplete .tt-dropdown-menu .aa-query .aa-query-cursor strong, .awesome-autocomplete .tt-dropdown-menu .aa-query .aa-query-default em {
+      color: #333333; }
+  .awesome-autocomplete .tt-dropdown-menu .aa-branding {
+    padding: 10px;
+    text-align: right;
+    font-size: 0.9em;
+    color: #888888; }
+    .awesome-autocomplete .tt-dropdown-menu .aa-branding img {
+      height: 18px;
+      vertical-align: bottom; }
+  .awesome-autocomplete .tt-dropdown-menu .aa-category {
+    padding: 5px 8px;
+    font-weight: bold;
+    text-align: left;
+    background-color: #F5F5F5; }
+  .awesome-autocomplete .tt-dropdown-menu .tt-suggestion {
+    padding: 10px 10px;
+    text-align: left;
+    border-bottom: 1px solid #EEEEEE; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion:last-child {
+      border-bottom: 0; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion em {
+      font-style: normal;
+      background-color: #FFFFC6;
+      color: #333333; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion:hover {
+      text-decoration: none; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion:hover .aa-name {
+        text-decoration: underline; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion .aa-infos {
+      float: right;
+      line-height: 3em;
+      color: #888888;
+      font-size: 0.9em; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion .aa-infos i {
+        font-size: 14px; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion .aa-name {
+      font-size: 1.1em; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user {
+      height: 35px; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-thumbnail {
+        float: left;
+        position: relative;
+        top: 3px;
+        width: 30px;
+        height: 30px;
+        margin-right: 10px;
+        border-radius: 3px;
+        overflow: hidden;
+        background-color: #F5F5F5; }
+        .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-thumbnail img {
+          width: 100%; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-name {
+        font-weight: bold; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-login {
+        color: #888888; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-company {
+        color: #333333; }
+        .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-user .aa-company i {
+          font-size: 14px;
+          color: #888888; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo {
+      height: 3em; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-thumbnail {
+        float: left;
+        position: relative;
+        top: 3px;
+        width: 30px;
+        height: 30px;
+        margin-right: 10px;
+        border-radius: 3px;
+        overflow: hidden;
+        background-color: #F5F5F5; }
+        .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-thumbnail img {
+          width: 100%; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-name {
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-weight: normal; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-repo-name {
+        font-weight: bold; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-repo .aa-description {
+        height: 1.3em;
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: #888888; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-thumbnail {
+      float: left;
+      position: relative;
+      top: 3px;
+      width: 30px;
+      height: 30px;
+      margin-right: 10px;
+      border-radius: 3px;
+      overflow: hidden;
+      background-color: #F5F5F5; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-thumbnail img {
+        width: 100%; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-name {
+      display: block;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-weight: normal; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-repo-name {
+      font-weight: bold; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-issue-number {
+      font-weight: bold; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-issue .aa-issue-body {
+      clear: both;
+      color: #888888;
+      overflow: hidden;
+      text-overflow: ellipsis; }
+    .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-your-repo {
+      height: 1.5em; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-your-repo .aa-name {
+        width: 85%;
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-weight: normal; }
+        .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-your-repo .aa-name .aa-repo {
+          font-weight: bold; }
+      .awesome-autocomplete .tt-dropdown-menu .tt-suggestion .aa-suggestion.aa-your-repo i {
+        font-size: 14px; }
+  .awesome-autocomplete .tt-dropdown-menu .tt-dataset-current-repo .tt-suggestion {
+    padding: 0; }
 .awesome-autocomplete .icon-delete {
   -webkit-transition: opacity 80ms;
   transition: opacity 80ms;
@@ -292,10 +234,6 @@
   height: 16px;
   width: 16px;
   z-index: 100;
-  opacity: 0;
-}
-.awesome-autocomplete .icon-delete.active {
-  opacity: 0.5;
-}
-
-/*# sourceMappingURL=content.css.map */
+  opacity: 0; }
+  .awesome-autocomplete .icon-delete.active {
+    opacity: 0.5; }

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-exec": "~0.4.5",
     "grunt-mkdir": "~0.1.1",
     "grunt-mocha-test": "~0.10.0",
-    "sinon": "~1.10.0",
-    "jpm": "0.0.21"
+    "grunt-sass": "^0.17.0",
+    "jpm": "0.0.21",
+    "sinon": "~1.10.0"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
I have switched `grunt-contrib-sass` to `grunt-sass ` then using `node-sass` instead of the `sass` Ruby gem, which not only improves performances, but it frees us from installing Ruby for compiling scss to css.
As you can see, compiling css with `node-sass` produces a little different css, but it is actually the same style.