### PR TITLE
Fix current repo search url extraction

### DIFF
--- a/code/js/content.js
+++ b/code/js/content.js
@@ -442,7 +442,7 @@
       }
     ]).on('typeahead:selected', function(event, suggestion, dataset) {
       if (dataset === 'current-repo') {
-        submit(suggestion.query, $('.pagehead .entry-title a.js-current-repository').attr('href') + '/search');
+        submit(suggestion.query, $('.js-site-search-form').data('repo-search-url') + '/search');
       } else if (dataset === 'users') {
         location.href = 'https://github.com/' + suggestion.login;
       } else if (dataset === 'repos' || dataset === 'private') {


### PR DESCRIPTION
Looks like GitHub has changed the HTML structure. Element with class `js-current-repository` doesn't exist in DOM, but the repo search url seems to be always available in `data-search-url` attribute of the input form.

I can reproduce this by following these steps:

1. Open any repository page
2. Remove "This repository" scope from the search with backspace
3. Type in a search term and press enter

Expected to see GitHub repository search page, but instead I got 404.


